### PR TITLE
feat: register custom components with Builder.io

### DIFF
--- a/src/builder/register.ts
+++ b/src/builder/register.ts
@@ -1,0 +1,43 @@
+import { Builder } from '@builder.io/react'
+import Navigation from '@/components/navigation/Navigation'
+import Footer from '@/components/footer/Footer'
+import { ProductCard } from '@/components/product/ProductCard'
+
+// Register site-specific components with Builder.io
+Builder.registerComponent(Navigation, {
+  name: 'Navigation',
+})
+
+Builder.registerComponent(Footer, {
+  name: 'Footer',
+})
+
+Builder.registerComponent(ProductCard, {
+  name: 'ProductCard',
+  inputs: [
+    {
+      name: 'product',
+      type: 'object',
+      subFields: [
+        { name: 'id', type: 'string' },
+        { name: 'name', type: 'string' },
+        { name: 'size', type: 'string' },
+        { name: 'description', type: 'string' },
+        { name: 'details', type: 'string' },
+        { name: 'price', type: 'string' },
+        {
+          name: 'features',
+          type: 'list',
+          subFields: [{ name: 'feature', type: 'string' }],
+        },
+        { name: 'bestFor', type: 'string' },
+        { name: 'image', type: 'string' },
+        { name: 'isProfessional', type: 'boolean' },
+        { name: 'isHospitality', type: 'boolean' },
+        { name: 'isNew', type: 'boolean' },
+        { name: 'isBestseller', type: 'boolean' },
+      ],
+    },
+  ],
+})
+

--- a/src/components/builder/BuilderPage.tsx
+++ b/src/components/builder/BuilderPage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import '@/builder/register'
 import { useState, useEffect } from 'react'
 import { BuilderComponent, builder } from '@builder.io/react'
 


### PR DESCRIPTION
## Summary
- register Navigation, Footer, and ProductCard components with Builder
- load Builder registration before rendering Builder content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font file from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_b_689daac269c0832098bf9cb14a4af661