### PR TITLE
Type-safe socket state in websocket example

### DIFF
--- a/examples/websocket/page.tsx
+++ b/examples/websocket/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { io } from 'socket.io-client';
+import { io, type Socket } from 'socket.io-client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -16,7 +16,7 @@ type Message = {
 export default function SocketDemo() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState('');
-  const [socket, setSocket] = useState<any>(null);
+  const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
 
   useEffect(() => {
@@ -44,19 +44,19 @@ export default function SocketDemo() {
   }, []);
 
   const sendMessage = () => {
-    if (socket && inputMessage.trim()) {
-      setMessages(prev => [...prev, {
-        text: inputMessage.trim(),
-        senderId: socket.id || 'user',
-        timestamp: new Date().toISOString()
-      }]);
-      socket.emit('message', {
-        text: inputMessage.trim(),
-        senderId: socket.id || 'user',
-        timestamp: new Date().toISOString()
-      });
-      setInputMessage('');
+    if (!socket || !inputMessage.trim()) {
+      return;
     }
+
+    const message = {
+      text: inputMessage.trim(),
+      senderId: socket.id || 'user',
+      timestamp: new Date().toISOString(),
+    };
+
+    setMessages(prev => [...prev, message]);
+    socket.emit('message', message);
+    setInputMessage('');
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- import Socket type and use `Socket | null` for client socket state
- ensure sendMessage exits early when socket missing and emit a single message object

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689dd0b3d020832094131881f7cbc264