### PR TITLE
feat: add hero component and builder registration

### DIFF
--- a/src/builder/register.ts
+++ b/src/builder/register.ts
@@ -2,6 +2,7 @@ import { Builder } from '@builder.io/react'
 import Navigation from '@/components/navigation/Navigation'
 import Footer from '@/components/footer/Footer'
 import { ProductCard } from '@/components/product/ProductCard'
+import Hero from '@/components/hero/Hero'
 
 // Register site-specific components with Builder.io
 Builder.registerComponent(Navigation, {
@@ -38,6 +39,15 @@ Builder.registerComponent(ProductCard, {
         { name: 'isBestseller', type: 'boolean' },
       ],
     },
+  ],
+})
+
+Builder.registerComponent(Hero, {
+  name: 'Hero',
+  inputs: [
+    { name: 'image', type: 'string' },
+    { name: 'heading', type: 'string' },
+    { name: 'subheading', type: 'string' },
   ],
 })
 

--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+interface HeroProps {
+  image: string
+  heading: string
+  subheading: string
+}
+
+export default function Hero({ image, heading, subheading }: HeroProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    setVisible(true)
+  }, [])
+
+  return (
+    <div
+      className="relative w-full h-[60vh] md:h-[70vh] bg-center bg-cover flex items-center justify-center"
+      style={{ backgroundImage: `url(${image})` }}
+    >
+      <div className="absolute inset-0 bg-black/40" />
+      <div
+        className={`relative z-10 text-center text-white p-4 max-w-2xl transition-opacity duration-1000 ${
+          visible ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
+        <h1 className="text-3xl md:text-5xl font-serif mb-4">{heading}</h1>
+        <p className="text-lg md:text-2xl mb-8">{subheading}</p>
+        <Link
+          href="/shop"
+          className="inline-block bg-gold-rich hover:bg-gold-light text-white px-6 py-3 uppercase tracking-wide"
+        >
+          SHOP NOW
+        </Link>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add configurable Hero component with background image, text overlay and CTA
- register Hero component with Builder for page builder use

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font file from `https://fonts.gstatic.com/...`)


------
https://chatgpt.com/codex/tasks/task_b_689de07da6008320b02e7bb877f16c19