### PR TITLE
feat: add category scroller component

### DIFF
--- a/src/builder/register.ts
+++ b/src/builder/register.ts
@@ -2,6 +2,7 @@ import { Builder } from '@builder.io/react'
 import Navigation from '@/components/navigation/Navigation'
 import Footer from '@/components/footer/Footer'
 import { ProductCard } from '@/components/product/ProductCard'
+import CategoryScroller from '@/components/categories/CategoryScroller'
 
 // Register site-specific components with Builder.io
 Builder.registerComponent(Navigation, {
@@ -36,6 +37,20 @@ Builder.registerComponent(ProductCard, {
         { name: 'isHospitality', type: 'boolean' },
         { name: 'isNew', type: 'boolean' },
         { name: 'isBestseller', type: 'boolean' },
+      ],
+    },
+  ],
+})
+
+Builder.registerComponent(CategoryScroller, {
+  name: 'CategoryScroller',
+  inputs: [
+    {
+      name: 'categories',
+      type: 'list',
+      subFields: [
+        { name: 'title', type: 'string' },
+        { name: 'image', type: 'string' },
       ],
     },
   ],

--- a/src/components/categories/CategoryScroller.tsx
+++ b/src/components/categories/CategoryScroller.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+interface Category {
+  title: string
+  image: string
+}
+
+interface CategoryScrollerProps {
+  categories: Category[]
+  className?: string
+}
+
+export function CategoryScroller({ categories, className = '' }: CategoryScrollerProps) {
+  return (
+    <div className={`flex flex-col gap-4 md:flex-row md:space-x-4 md:overflow-x-auto ${className}`}>
+      {categories.map((category) => (
+        <div
+          key={category.title}
+          className="relative group flex-shrink-0 w-full md:w-64 h-48 overflow-hidden rounded-lg"
+        >
+          <img
+            src={category.image}
+            alt={category.title}
+            className="w-full h-full object-cover transition-transform duration-300 brightness-90 group-hover:scale-105 group-hover:brightness-110"
+          />
+          <div className="absolute inset-0 bg-black/30 flex items-end">
+            <span className="text-white p-4 text-lg font-semibold uppercase tracking-wide">
+              {category.title}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CategoryScroller


### PR DESCRIPTION
## Summary
- add CategoryScroller component for horizontal scrolling category tiles
- register CategoryScroller with Builder.io for drag-and-drop arrangement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689de07eb7cc8320bfbf329e2454b6b4