### PR TITLE
feat: add product images and cart integration

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,23 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
 import Link from "next/link";
-
-export interface Product {
-  id: string;
-  name: string;
-  size: string;
-  description: string;
-  details: string;
-  price: string;
-  features: string[];
-  bestFor: string;
-  image?: string;
-  isProfessional?: boolean;
-  isHospitality?: boolean;
-  isNew?: boolean;
-  isBestseller?: boolean;
-}
+import { Heart, Check } from "lucide-react";
+import { useState } from "react";
+import { useCart } from "@/hooks/use-cart";
+import type { Product } from "@/types/product";
 
 interface ProductCardProps {
   product: Product;
@@ -25,21 +14,41 @@ interface ProductCardProps {
 }
 
 export function ProductCard({ product, className = "" }: ProductCardProps) {
+  const { addItem } = useCart();
+  const [added, setAdded] = useState(false);
+
+  const handleAdd = () => {
+    addItem(product);
+    setAdded(true);
+    setTimeout(() => setAdded(false), 1500);
+  };
+
   return (
     <Card className={`border-taupe-light bg-white hover:shadow-lg transition-shadow ${className}`}>
       <CardHeader className="text-center pb-4">
-        <div className="relative">
-          <div className="bg-taupe-light/20 h-48 rounded-lg mb-4 flex items-center justify-center">
-            <div className="text-center">
-              <div className="w-20 h-32 bg-gold-light/30 rounded mx-auto mb-4 flex items-center justify-center">
-                <span className="text-2xl font-serif text-gold-rich">{product.size}</span>
-              </div>
-              <p className="text-sm text-muted-foreground">Product visualization</p>
+        <div className="relative group">
+          {product.image && (
+            <div className="overflow-hidden rounded-lg mb-4">
+              <Image
+                src={product.image}
+                alt={product.name}
+                width={300}
+                height={192}
+                className="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
             </div>
-          </div>
-          
+          )}
+          <button className="absolute top-2 right-2 bg-black/50 text-white p-1 rounded-full">
+            <Heart className="w-5 h-5" />
+          </button>
+
           {/* Badges */}
           <div className="absolute top-2 left-2 flex flex-col gap-2">
+            {product.salePrice && (
+              <Badge variant="secondary" className="bg-red-500 text-white">
+                Sale
+              </Badge>
+            )}
             {product.isNew && (
               <Badge variant="secondary" className="bg-gold-rich text-white">
                 New
@@ -65,17 +74,21 @@ export function ProductCard({ product, className = "" }: ProductCardProps) {
 
         <div className="space-y-2">
           <CardTitle className="text-2xl font-serif text-foreground">
-            {product.size}
+            {product.name}
           </CardTitle>
           <p className="text-lg text-gold-rich font-medium">
-            {product.description}
-          </p>
-          <p className="text-muted-foreground">
-            {product.details}
+            {product.salePrice ? (
+              <>
+                <span className="line-through mr-2">{product.price}</span>
+                <span>{product.salePrice}</span>
+              </>
+            ) : (
+              product.price
+            )}
           </p>
         </div>
       </CardHeader>
-      
+
       <CardContent className="space-y-6">
         <div>
           <h4 className="font-semibold text-foreground mb-3">Features:</h4>
@@ -99,25 +112,21 @@ export function ProductCard({ product, className = "" }: ProductCardProps) {
           <p className="text-sm text-muted-foreground">{product.bestFor}</p>
         </div>
 
-        <div className="text-center">
-          <p className="text-2xl font-serif text-foreground mb-4">
-            {product.price}
-          </p>
-          <div className="space-y-2">
-            <Button 
-              className="w-full bg-gold-rich hover:bg-gold-light text-white"
-              size="lg"
-            >
-              {product.price.includes("Contact") ? "Inquire Now" : "Add to Cart"}
-            </Button>
-            <Button 
-              variant="outline" 
-              className="w-full border-gold-rich text-gold-rich hover:bg-gold-rich hover:text-white"
-              asChild
-            >
-              <Link href={`/shop/${product.id}`}>View Details</Link>
-            </Button>
-          </div>
+        <div className="text-center space-y-2">
+          <Button
+            onClick={handleAdd}
+            className="w-full bg-gold-rich hover:bg-gold-light text-white"
+            size="lg"
+          >
+            {added ? <Check className="w-5 h-5" /> : "ADD TO CART"}
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full border-gold-rich text-gold-rich hover:bg-gold-rich hover:text-white"
+            asChild
+          >
+            <Link href={`/shop/${product.id}`}>View Details</Link>
+          </Button>
         </div>
       </CardContent>
     </Card>
@@ -131,7 +140,7 @@ interface ProductGridProps {
 
 export function ProductGrid({ products, className = "" }: ProductGridProps) {
   return (
-    <div className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 ${className}`}>
+    <div className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 ${className}`}>
       {products.map((product) => (
         <ProductCard key={product.id} product={product} />
       ))}

--- a/src/hooks/use-cart.ts
+++ b/src/hooks/use-cart.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import type { Product } from "@/types/product";
+
+interface CartItem {
+  product: Product;
+  quantity: number;
+}
+
+interface CartState {
+  items: CartItem[];
+  addItem: (product: Product) => void;
+}
+
+export const useCart = create<CartState>((set) => ({
+  items: [],
+  addItem: (product) =>
+    set((state) => {
+      const existing = state.items.find(
+        (item) => item.product.id === product.id
+      );
+      if (existing) {
+        return {
+          items: state.items.map((item) =>
+            item.product.id === product.id
+              ? { ...item, quantity: item.quantity + 1 }
+              : item
+          ),
+        };
+      }
+      return { items: [...state.items, { product, quantity: 1 }] };
+    }),
+}));

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,16 @@
+export interface Product {
+  id: string;
+  name: string;
+  size: string;
+  description: string;
+  details: string;
+  price: string;
+  salePrice?: string;
+  features: string[];
+  bestFor: string;
+  image?: string;
+  isProfessional?: boolean;
+  isHospitality?: boolean;
+  isNew?: boolean;
+  isBestseller?: boolean;
+}


### PR DESCRIPTION
## Summary
- show product images with wishlist icon and sale badges
- integrate product card with cart state and checkmark feedback
- support responsive product grid layouts across breakpoints

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Module '@sanity/image-url' has no exported member 'SanityImageSource')*


------
https://chatgpt.com/codex/tasks/task_b_689de0806aac8320935f5beae7f3567d