### PR TITLE
feat: add about section component

### DIFF
--- a/src/builder/register.ts
+++ b/src/builder/register.ts
@@ -2,6 +2,7 @@ import { Builder } from '@builder.io/react'
 import Navigation from '@/components/navigation/Navigation'
 import Footer from '@/components/footer/Footer'
 import { ProductCard } from '@/components/product/ProductCard'
+import AboutSection from '@/components/about/AboutSection'
 
 // Register site-specific components with Builder.io
 Builder.registerComponent(Navigation, {
@@ -10,6 +11,16 @@ Builder.registerComponent(Navigation, {
 
 Builder.registerComponent(Footer, {
   name: 'Footer',
+})
+
+Builder.registerComponent(AboutSection, {
+  name: 'AboutSection',
+  inputs: [
+    { name: 'image', type: 'string', friendlyName: 'Image URL' },
+    { name: 'title', type: 'string' },
+    { name: 'body', type: 'longText' },
+    { name: 'parallax', type: 'boolean', defaultValue: false },
+  ],
 })
 
 Builder.registerComponent(ProductCard, {

--- a/src/components/about/AboutSection.tsx
+++ b/src/components/about/AboutSection.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Image from 'next/image'
+import { useRef } from 'react'
+import { motion, useInView, useScroll, useTransform } from 'framer-motion'
+
+interface AboutSectionProps {
+  image: string
+  title: string
+  body: string
+  parallax?: boolean
+}
+
+export default function AboutSection({
+  image,
+  title,
+  body,
+  parallax = false,
+}: AboutSectionProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const textRef = useRef<HTMLDivElement>(null)
+  const textInView = useInView(textRef, { once: true, margin: '-100px' })
+  const { scrollYProgress } = useScroll({ target: containerRef, offset: ['start end', 'end start'] })
+  const y = useTransform(scrollYProgress, [0, 1], parallax ? [-50, 50] : [0, 0])
+
+  return (
+    <section ref={containerRef} className="flex flex-col md:flex-row items-center gap-8">
+      <motion.div className="w-full md:w-1/2 overflow-hidden" style={parallax ? { y } : undefined}>
+        <Image src={image} alt={title} width={800} height={600} className="w-full h-full object-cover" />
+      </motion.div>
+      <motion.div
+        ref={textRef}
+        initial={{ opacity: 0, y: 20 }}
+        animate={textInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.6 }}
+        className="w-full md:w-1/2"
+      >
+        <h2 className="text-3xl font-serif mb-4">{title}</h2>
+        <p className="text-muted-foreground">{body}</p>
+      </motion.div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add AboutSection component with optional parallax and scroll fade-in
- register AboutSection for Builder.io usage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689de081ada4832087476ed782ee9e23