### PR TITLE
feat(builder): register new homepage components

### DIFF
--- a/src/builder/register.ts
+++ b/src/builder/register.ts
@@ -2,6 +2,9 @@ import { Builder } from '@builder.io/react'
 import Navigation from '@/components/navigation/Navigation'
 import Footer from '@/components/footer/Footer'
 import { ProductCard } from '@/components/product/ProductCard'
+import Hero from '@/components/hero/Hero'
+import CategoryScroller from '@/components/category/CategoryScroller'
+import AboutSection from '@/components/about/AboutSection'
 
 // Register site-specific components with Builder.io
 Builder.registerComponent(Navigation, {
@@ -36,8 +39,45 @@ Builder.registerComponent(ProductCard, {
         { name: 'isHospitality', type: 'boolean' },
         { name: 'isNew', type: 'boolean' },
         { name: 'isBestseller', type: 'boolean' },
+        { name: 'ctaText', type: 'string' },
+        { name: 'ctaLink', type: 'string' },
       ],
     },
+  ],
+})
+
+Builder.registerComponent(Hero, {
+  name: 'Hero',
+  inputs: [
+    { name: 'title', type: 'string' },
+    { name: 'subtitle', type: 'string' },
+    { name: 'backgroundImage', type: 'string' },
+    { name: 'ctaText', type: 'string' },
+    { name: 'ctaLink', type: 'string' },
+  ],
+})
+
+Builder.registerComponent(CategoryScroller, {
+  name: 'CategoryScroller',
+  inputs: [
+    {
+      name: 'categories',
+      type: 'list',
+      subFields: [
+        { name: 'title', type: 'string' },
+        { name: 'image', type: 'string' },
+        { name: 'link', type: 'string' },
+      ],
+    },
+  ],
+})
+
+Builder.registerComponent(AboutSection, {
+  name: 'AboutSection',
+  inputs: [
+    { name: 'title', type: 'string' },
+    { name: 'text', type: 'string', richText: true },
+    { name: 'image', type: 'string' },
   ],
 })
 

--- a/src/components/about/AboutSection.tsx
+++ b/src/components/about/AboutSection.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image'
+
+interface AboutSectionProps {
+  title: string
+  text: string
+  image?: string
+}
+
+export default function AboutSection({ title, text, image }: AboutSectionProps) {
+  return (
+    <section className="grid md:grid-cols-2 gap-8 items-center w-full">
+      <div>
+        <h2 className="text-3xl font-serif mb-4">{title}</h2>
+        <p className="text-muted-foreground whitespace-pre-line">{text}</p>
+      </div>
+      {image && (
+        <div className="relative w-full h-64">
+          <Image src={image} alt={title} fill className="object-cover rounded" />
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/category/CategoryScroller.tsx
+++ b/src/components/category/CategoryScroller.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+interface Category {
+  title: string
+  image: string
+  link: string
+}
+
+interface CategoryScrollerProps {
+  categories: Category[]
+}
+
+export default function CategoryScroller({ categories }: CategoryScrollerProps) {
+  return (
+    <div className="overflow-x-auto w-full">
+      <div className="flex space-x-4">
+        {categories.map((cat, index) => (
+          <Link key={index} href={cat.link} className="flex-shrink-0 w-48">
+            <div className="relative h-32 w-full mb-2">
+              {cat.image && (
+                <Image
+                  src={cat.image}
+                  alt={cat.title}
+                  fill
+                  className="object-cover rounded"
+                />
+              )}
+            </div>
+            <p className="text-center text-sm font-medium">{cat.title}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+
+interface HeroProps {
+  title: string
+  subtitle?: string
+  backgroundImage?: string
+  ctaText?: string
+  ctaLink?: string
+}
+
+export default function Hero({ title, subtitle, backgroundImage, ctaText, ctaLink }: HeroProps) {
+  return (
+    <section
+      className="relative w-full h-[400px] flex items-center justify-center text-center text-white"
+      style={{
+        backgroundImage: backgroundImage ? `url(${backgroundImage})` : undefined,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      {backgroundImage && <div className="absolute inset-0 bg-black/40" />}
+      <div className="relative z-10 p-4">
+        <h1 className="text-4xl font-serif mb-2">{title}</h1>
+        {subtitle && <p className="text-lg mb-4">{subtitle}</p>}
+        {ctaText && ctaLink && (
+          <Link
+            href={ctaLink}
+            className="inline-block bg-gold-rich text-white px-4 py-2 rounded"
+          >
+            {ctaText}
+          </Link>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -17,6 +17,8 @@ export interface Product {
   isHospitality?: boolean;
   isNew?: boolean;
   isBestseller?: boolean;
+  ctaText?: string;
+  ctaLink?: string;
 }
 
 interface ProductCardProps {
@@ -104,18 +106,20 @@ export function ProductCard({ product, className = "" }: ProductCardProps) {
             {product.price}
           </p>
           <div className="space-y-2">
-            <Button 
+            <Button
               className="w-full bg-gold-rich hover:bg-gold-light text-white"
               size="lg"
             >
               {product.price.includes("Contact") ? "Inquire Now" : "Add to Cart"}
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               className="w-full border-gold-rich text-gold-rich hover:bg-gold-rich hover:text-white"
               asChild
             >
-              <Link href={`/shop/${product.id}`}>View Details</Link>
+              <Link href={product.ctaLink || `/shop/${product.id}`}>
+                {product.ctaText || 'View Details'}
+              </Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- register Hero, CategoryScroller, AboutSection and enhanced ProductCard with Builder.io
- add minimal Hero, CategoryScroller and AboutSection components
- extend ProductCard with configurable call-to-action link and text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689de0870028832087bb0cba002cb7e5